### PR TITLE
Fix: 데이터베이스 MonitorExp 형식 수정

### DIFF
--- a/main.go
+++ b/main.go
@@ -338,17 +338,17 @@ func main() {
 				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
 
-			var video VideoEntity
+			var Video VideoEntity
 
-			err = db.First(&video, binder.ContentId).Error
+			err = db.First(&Video, binder.ContentId).Error
 			if err == gorm.ErrRecordNotFound {
 				return echo.NewHTTPError(http.StatusNotFound, "No record")
 			} else if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 			}
 
-			video.MonitorExp = time.Now().Add(MonitorExpiresTime).UnixMilli()
-			db.Save(&video)
+			Video.MonitorExp = time.Now().Add(MonitorExpiresTime).UnixMilli()
+			db.Save(&Video)
 
 			return c.JSON(http.StatusOK, echo.Map{
 				"message": fmt.Sprintf("Time to monitor ends in %d minutes", MonitroEpxiresValue),
@@ -383,7 +383,7 @@ type TagList []string
 type VideoEntity struct {
 	ContentId     uuid.UUID  `gorm:"type:varchar(36);primaryKey;not null;" json:"contentId"`
 	StateLabel    Videostate `gorm:"type:varchar(30);not null;default:NONE;"  json:"stateLabel" validate:"eq=APPORVE|eq=DENY|eq=NONE"`
-	MonitorExp    int64      `gorm:"autoUpdateTime:milli;" json:"monitorExp"`
+	MonitorExp    int64      `gorm:"not null;" json:"monitorExp"`
 	Subject       string     `gorm:"type:varchar(60);not null" json:"subject"`
 	Description   string     `gorm:"type:varchar(300);not null" json:"description"`
 	Thumb         string     `gorm:"not null" json:"thumb"`


### PR DESCRIPTION
## 최근 작업 주제 
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

## 구현 목표 
- 비디오 상태 검수중이 안되는 버그 해결

## 구현 사항 설명 
1. 데이터베이스 MonitorExp 형식 수정
- 비디오 상태가 안 바뀌는 문제 해결
- DB에 MonitorExp가 autoUpdateTime로 설정되어 있어서 로컬 타임으로 변경되서 저장되는 부분 수정
