### PR TITLE
Mod: 리스트 페이지 반환값에서 전체 페이지 수 -> 전체 아이템 수로 변경

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql/driver"
 	"fmt"
-	"math"
 	"strings"
 
 	// "database/sql"
@@ -319,11 +318,11 @@ func main() {
 
 			type Contents struct {
 				Items      []VideoEntity `json:"items"`
-				TotalPages int           `json:"totalPages"`
+				TotalItems int           `json:"totalItems"`
 			}
 
-			totalPages := int(math.Ceil(float64(total) / float64(limit)))
-			result := Contents{Items: items, TotalPages: totalPages}
+			// totalPages := int(math.Ceil(float64(total) / float64(limit)))
+			result := Contents{Items: items, TotalItems: int(total)}
 			return c.JSON(http.StatusOK, result)
 		})
 


### PR DESCRIPTION
## 최근 작업 주제 
- [ ] 기능 추가
- [X] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 구현 목표 
- 리스트 페이지 반환 값 변경

## 구현 사항 설명 
1. 리스트 페이지 반환 값 변경
- 전체 페이지 수를 계산해서 반환하던 값을 전체 아이템 수로 변경